### PR TITLE
Fix bug: undefined attachment

### DIFF
--- a/dist/attachment.js
+++ b/dist/attachment.js
@@ -1,5 +1,6 @@
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
+exports.Attachment = void 0;
 class Attachment {
     constructor(content, mimeType, filename) {
         this.toObject = () => {

--- a/dist/index.js
+++ b/dist/index.js
@@ -1,9 +1,16 @@
 "use strict";
-function __export(m) {
-    for (var p in m) if (!exports.hasOwnProperty(p)) exports[p] = m[p];
-}
+var __createBinding = (this && this.__createBinding) || (Object.create ? (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    Object.defineProperty(o, k2, { enumerable: true, get: function() { return m[k]; } });
+}) : (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    o[k2] = m[k];
+}));
+var __exportStar = (this && this.__exportStar) || function(m, exports) {
+    for (var p in m) if (p !== "default" && !exports.hasOwnProperty(p)) __createBinding(exports, m, p);
+};
 Object.defineProperty(exports, "__esModule", { value: true });
-__export(require("./sendgrid.module"));
-__export(require("./sendgrid.service"));
+__exportStar(require("./sendgrid.module"), exports);
+__exportStar(require("./sendgrid.service"), exports);
 var attachment_1 = require("./attachment");
-exports.Attachment = attachment_1.Attachment;
+Object.defineProperty(exports, "Attachment", { enumerable: true, get: function () { return attachment_1.Attachment; } });

--- a/dist/sendgrid.constants.js
+++ b/dist/sendgrid.constants.js
@@ -1,4 +1,5 @@
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
+exports.SENDGRID_MODULE_OPTIONS = exports.SENDGRID_CONFIG = void 0;
 exports.SENDGRID_CONFIG = 'SENDGRID_CONFIG';
 exports.SENDGRID_MODULE_OPTIONS = 'SENDGRID_MODULE_OPTIONS';

--- a/dist/sendgrid.module.js
+++ b/dist/sendgrid.module.js
@@ -7,6 +7,7 @@ var __decorate = (this && this.__decorate) || function (decorators, target, key,
 };
 var SendGridModule_1;
 Object.defineProperty(exports, "__esModule", { value: true });
+exports.SendGridModule = void 0;
 const common_1 = require("@nestjs/common");
 const sendgrid_service_1 = require("./sendgrid.service");
 const sendgrid_constants_1 = require("./sendgrid.constants");

--- a/dist/sendgrid.service.d.ts
+++ b/dist/sendgrid.service.d.ts
@@ -1,9 +1,10 @@
+/// <reference types="request" />
 import { SendGridConfig } from './interfaces/email.interface';
 import { Attachment } from './attachment';
 export declare class SendGridService {
     private readonly sendGridConfig;
     constructor(sendGridConfig: SendGridConfig);
-    sendMail(to: string, subject: string, html: string, attachments?: Attachment[]): Promise<[any, {}]>;
-    renderAndSendMail(to: string, subject: string, templatePath: string, data: any, attachments?: Attachment[]): Promise<[any, {}]>;
+    sendMail(to: string, subject: string, html: string, attachments?: Attachment[]): Promise<[import("request").Response, {}]>;
+    renderAndSendMail(to: string, subject: string, templatePath: string, data: any, attachments?: Attachment[]): Promise<[import("request").Response, {}]>;
     private send;
 }

--- a/dist/sendgrid.service.js
+++ b/dist/sendgrid.service.js
@@ -21,6 +21,7 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
     });
 };
 Object.defineProperty(exports, "__esModule", { value: true });
+exports.SendGridService = void 0;
 const common_1 = require("@nestjs/common");
 const sendgrid_constants_1 = require("./sendgrid.constants");
 const Sendgrid = require("@sendgrid/mail");
@@ -43,7 +44,7 @@ let SendGridService = class SendGridService {
             return yield this.send(to, subject, output, attachments);
         });
     }
-    send(to, subject, html, attachments) {
+    send(to, subject, html, attachments = []) {
         return __awaiter(this, void 0, void 0, function* () {
             if (this.sendGridConfig.devOptions) {
                 if (this.sendGridConfig.devOptions.disableSend) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "nest-sendgrid",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nest-sendgrid",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "main": "dist/index.js",
   "scripts": {
     "build": "tsc -p tsconfig.lib.json"

--- a/src/sendgrid.service.ts
+++ b/src/sendgrid.service.ts
@@ -25,7 +25,7 @@ export class SendGridService {
     return await this.send(to, subject, output, attachments);
   }
 
-  private async send(to: string, subject: string, html: string, attachments?: Attachment[]) {
+  private async send(to: string, subject: string, html: string, attachments: Attachment[] = []) {
     if(this.sendGridConfig.devOptions) {
       if (this.sendGridConfig.devOptions.disableSend) {
         return;


### PR DESCRIPTION
This bug was introduced in #2.

When not given, the attachments parameter will be undefined and the call to map will trigger an exception.

This commit fixes that by defining an empty array as the default value to this parameter.

This PR also bumps the package version to 1.0.1.